### PR TITLE
Removed PoWH from title.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="The Most Powerful Infrastructure for Decentralized Applications">
     <meta name="author" content="">
     <link rel="shortcut icon" href="https://d340lr3764rrcr.cloudfront.net/Images/eos_gem.ico">
-    <title> EthPyramid | Proof of Weak Hands</title>
+    <title> EthPyramid </title>
     <link rel="stylesheet" href="css/jquery.modal.min.css">
     <link href="https://fonts.googleapis.com/css?family=Ubuntu:400,500,700" rel="stylesheet">
 	<script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>


### PR DESCRIPTION
Removed reference to PoWH in the page title. Could be misleading.